### PR TITLE
Fix #18: --url localfile doesn't work on Windows.

### DIFF
--- a/ffpuppet/core.py
+++ b/ffpuppet/core.py
@@ -736,7 +736,7 @@ class FFPuppet(object):
         log.debug("requested location: %r", location)
         if location is not None:
             if os.path.isfile(location):
-                location = "file:///%s" % pathname2url(os.path.abspath(location).lstrip('/'))
+                location = "file:%s" % pathname2url(os.path.realpath(location))
             elif re.match(r"http(s)?://", location, re.IGNORECASE) is None:
                 raise IOError("Cannot find %s" % os.path.abspath(location))
 


### PR DESCRIPTION
After this change yields:

    windows:
    D ffpuppet [2017-09-07 14:55:24] sending response with redirect url: 'file:///C:/Users/user/Desktop/tc.html'
    linux:
    D ffpuppet [2017-09-07 15:01:45] sending response with redirect url: 'file:/home/user/Desktop/tc.html'

Both redirects work properly.