### PR TITLE
Add support for arbitrary/multiple extensions.

### DIFF
--- a/ffpuppet/core.py
+++ b/ffpuppet/core.py
@@ -660,7 +660,7 @@ class FFPuppet(object):
                 extensions = extension
             else:
                 extensions = [extension]
-            if extensions:
+            if extensions and not os.path.isdir(os.path.join(profile, "extensions")):
                 os.mkdir(os.path.join(profile, "extensions"))
             for ext in extensions:
                 if os.path.isfile(ext) and ext.endswith(".xpi"):
@@ -675,7 +675,7 @@ class FFPuppet(object):
                             with open(os.path.join(ext, "manifest.json")) as manifest:
                                 manifest = json.load(manifest)
                             ext_name = manifest["applications"]["gecko"]["id"]
-                        except Exception as exc:
+                        except (IOError, KeyError, ValueError) as exc:
                             log.debug("Failed to parse manifest.json: %s", exc)
                     elif os.path.isfile(os.path.join(ext, "install.rdf")):
                         try:
@@ -686,7 +686,7 @@ class FFPuppet(object):
                             ids = tree.findall("./x:Description/em:id", namespaces=xmlns)
                             assert len(ids) == 1
                             ext_name = ids[0].text
-                        except Exception as exc:
+                        except (AssertionError, IOError, ElementTree.ParseError) as exc:
                             log.debug("Failed to parse install.rdf: %s", exc)
                     if ext_name is None:
                         raise RuntimeError("Failed to find extension id in manifest: %r" % ext)

--- a/ffpuppet/test_ffpuppet.py
+++ b/ffpuppet/test_ffpuppet.py
@@ -732,7 +732,7 @@ class PuppetTests(TestCase): # pylint: disable=too-many-public-methods
         self.assertLess(len(data), t_size + len(e_token))
         self.assertFalse(data.endswith(e_token))
 
-    def test_31(self):
+    def test_32(self):
         "test create_profile() extension support"
 
         # create a profile with a non-existent ext


### PR DESCRIPTION
Extensions are not going away, and we should support installing them for testing even if we stop using them regularly (which is not planned). This supports arbitrary add-ons by looking up the extension ID in the manifest (may be fragile for legacy add-ons because of XML namespaces). 

Fixes #4.