### PR TITLE
Add CPUID features mask for rr record command.

### DIFF
--- a/ffpuppet/core.py
+++ b/ffpuppet/core.py
@@ -502,7 +502,9 @@ class FFPuppet(object):
                 "--args"] + cmd # enable gdb
 
         if self._use_rr:
-            cmd = ["rr", "record"] + cmd
+            cmd = ["rr", "record",
+                   "--disable-cpuid-features", "0x80050440,0x40140400",
+                   "--disable-cpuid-features-ext", "0xfd639040,0xffffffff,0xf3ffffff"] + cmd
 
         return cmd
 


### PR DESCRIPTION
This is obtained from the replay machine by running `rr cpufeatures`,
and the results from other machines can be ORed with these if needed.