### PR TITLE
Always save browser logs if an issue is detected

### DIFF
--- a/ffpuppet/core.py
+++ b/ffpuppet/core.py
@@ -587,8 +587,9 @@ class FFPuppet(object):  # pylint: disable=too-many-instance-attributes
         @rtype: None
         @return: None
         """
-
         assert self._launches > -1, "clean_up() has been called"
+        assert log_limit >= 0
+        assert memory_limit >= 0
         if self._proc is not None:
             raise LaunchError("Process is already running")
 
@@ -606,8 +607,6 @@ class FFPuppet(object):  # pylint: disable=too-many-instance-attributes
                 raise IOError("Cannot find %r" % location)
 
         self.reason = None
-        log_limit = max(log_limit, 0)
-        memory_limit = max(memory_limit, 0)
         launch_timeout = max(launch_timeout, self.LAUNCH_TIMEOUT_MIN)
         log.debug("launch timeout: %d", launch_timeout)
 

--- a/ffpuppet/main.py
+++ b/ffpuppet/main.py
@@ -109,6 +109,10 @@ def parse_args(argv=None):
         help="Scan the browser logs for the given value and close browser if detected. " \
              "For example '-a ###!!! ASSERTION:' would be used to detect soft assertions.")
     report_group.add_argument(
+        "--launch-timeout", type=int, default=300,
+        help="Number of seconds to wait for the browser to become " \
+             "responsive after launching. (default: %(default)s)")
+    report_group.add_argument(
         "-l", "--logs", default=".",
         help="Location to save browser logs. A sub-directory containing the browser logs" \
              " will be created.")
@@ -124,10 +128,6 @@ def parse_args(argv=None):
     report_group.add_argument(
         "--save-all", action="store_true",
         help="Always save logs. By default logs are saved only when an issue is detected.")
-    report_group.add_argument(
-        "-t", "--timeout", type=int, default=300,
-        help="Number of seconds to wait for the browser to become " \
-             "responsive after launching. (default: %(default)s)")
 
     if sys.platform.startswith("linux"):
         dbg_group = parser.add_argument_group("Available Debuggers")
@@ -202,7 +202,7 @@ def main(argv=None):  # pylint: disable=missing-docstring
         ffp.launch(
             args.binary,
             location=args.url,
-            launch_timeout=args.timeout,
+            launch_timeout=args.launch_timeout,
             log_limit=args.log_limit,
             memory_limit=args.memory,
             prefs_js=args.prefs,

--- a/ffpuppet/main.py
+++ b/ffpuppet/main.py
@@ -153,6 +153,8 @@ def parse_args(argv=None):
     args = parser.parse_args(argv)
 
     # sanity check
+    if not os.path.isfile(args.binary):
+        parser.error("Invalid browser binary %r" % args.binary)
     if args.extension is not None:
         for ext in args.extension:
             if not os.path.exists(ext):

--- a/ffpuppet/main.py
+++ b/ffpuppet/main.py
@@ -86,60 +86,65 @@ def parse_args(argv=None):
         "INFO": logging.INFO,
         "DEBUG": logging.DEBUG}
 
-    parser = argparse.ArgumentParser(description="Firefox launcher/wrapper")
+    parser = argparse.ArgumentParser(
+        description="FFPuppet - Firefox process launcher and log collector. Happy bug hunting!")
     parser.add_argument(
         "binary",
         help="Firefox binary to launch")
-    parser.add_argument(
-        "-a", "--abort-token", action="append", default=list(),
-        help="Scan the log for the given value and close browser on detection. " \
-             "For example '-a ###!!! ASSERTION:' would be used to detect soft assertions.")
     parser.add_argument(
         "-d", "--dump", action="store_true",
         help="Display browser logs on process exit. This is only meant to provide a " \
              "summary of the logs. To collect full logs use '--log'.")
     parser.add_argument(
-        "-e", "--extension", action="append",
-        help="Use the fuzzPriv extension. Specify the path to the xpi or the directory " \
-             "containing the unpacked extension.")
-    parser.add_argument(
-        "-l", "--log",
-        help="Location to save logs. If the path exists it must be empty, if it " \
-             "does not exist it will be created.")
-    parser.add_argument(
         "--log-level", default="INFO",
         help="Configure console logging. Options: %s (default: %%(default)s)" %
         ", ".join(k for k, v in sorted(log_level_map.items(), key=lambda x: x[1])))
-    parser.add_argument(
-        "--log-limit", type=int, default=0,
-        help="Browser log file size limit in MBs (default: %(default)s, no limit)")
-    parser.add_argument(
-        "-m", "--memory", type=int, default=0,
-        help="Browser process memory limit in MBs (default: %(default)s, no limit)")
-    parser.add_argument(
-        "--poll-interval", type=float, default=0.5,
-        help="Delay between checks for results (default: %(default)s)")
-    parser.add_argument(
+
+    cfg_group = parser.add_argument_group("Browser Configuration")
+    cfg_group.add_argument(
+        "-e", "--extension", action="append",
+        help="Install extensions. Specify the path to the xpi or the directory " \
+             "containing the unpacked extension.")
+    cfg_group.add_argument(
         "-p", "--prefs",
         help="Custom prefs.js file to use (default: profile default)")
-    parser.add_argument(
+    cfg_group.add_argument(
         "-P", "--profile",
         help="Profile to use. This is non-destructive. A copy of the target profile " \
              "will be used. (default: temporary profile)")
-    parser.add_argument(
-        "-t", "--timeout", type=int, default=300,
-        help="Number of seconds to wait for the browser to become " \
-             "responsive after launching. (default: %(default)s)")
-    parser.add_argument(
+    cfg_group.add_argument(
         "-u", "--url",
         help="Server URL or path to local file to load.")
     if sys.platform.startswith("linux"):
-        parser.add_argument(
+        cfg_group.add_argument(
             "--xvfb", action="store_true",
             help="Use Xvfb")
 
-    dbg_group = parser.add_argument_group("Available Debuggers")
+    report_group = parser.add_argument_group("Issue Detection & Reporting")
+    report_group.add_argument(
+        "-a", "--abort-token", action="append", default=list(),
+        help="Scan the browser logs for the given value and close browser if detected. " \
+             "For example '-a ###!!! ASSERTION:' would be used to detect soft assertions.")
+    report_group.add_argument(
+        "-l", "--log",
+        help="Location to save logs. If the path exists it must be empty, if it " \
+             "does not exist it will be created.")
+    report_group.add_argument(
+        "--log-limit", type=int, default=0,
+        help="Browser log file size limit in MBs (default: %(default)s, no limit)")
+    report_group.add_argument(
+        "-m", "--memory", type=int, default=0,
+        help="Browser process memory limit in MBs (default: %(default)s, no limit)")
+    report_group.add_argument(
+        "--poll-interval", type=float, default=0.5,
+        help="Delay between checks for results (default: %(default)s)")
+    report_group.add_argument(
+        "-t", "--timeout", type=int, default=300,
+        help="Number of seconds to wait for the browser to become " \
+             "responsive after launching. (default: %(default)s)")
+
     if sys.platform.startswith("linux"):
+        dbg_group = parser.add_argument_group("Available Debuggers")
         dbg_group.add_argument(
             "--gdb", action="store_true",
             help="Use GDB")

--- a/ffpuppet/test_main.py
+++ b/ffpuppet/test_main.py
@@ -38,7 +38,7 @@ def test_main_02(mocker, tmp_path):
     fake_time.sleep.side_effect = KeyboardInterrupt
     out_logs = tmp_path / "logs"
     out_logs.mkdir()
-    main(["fake_bin", "-d", "-a", "token", "-v"])
+    main(["fake_bin", "-d", "-a", "token", "--log-level", "DEBUG"])
     assert fake_ffp.return_value.add_abort_token.call_count == 1
     assert fake_ffp.return_value.get_pid.call_count == 1
     assert fake_ffp.return_value.is_healthy.call_count == 1
@@ -61,6 +61,9 @@ def test_parse_args_01(tmp_path):
     (tmp_path / "junk.log").touch()
     with pytest.raises(SystemExit):
         parse_args(["fake_bin", "--log", str(tmp_path)])
+    # invalid log level
+    with pytest.raises(SystemExit):
+        parse_args(["fake_bin", "--log-level", "bad"])
     assert parse_args(["fake_bin"])
 
 def test_dump_to_console_01(tmp_path):

--- a/ffpuppet/test_main.py
+++ b/ffpuppet/test_main.py
@@ -59,6 +59,12 @@ def test_parse_args_01(tmp_path):
         parse_args(["fake_bin"])
     fake_bin = (tmp_path / "fake.bin")
     fake_bin.touch()
+    # invalid log-limit
+    with pytest.raises(SystemExit):
+        parse_args([str(fake_bin), "--log-limit", "-1"])
+    # invalid memory limit
+    with pytest.raises(SystemExit):
+        parse_args([str(fake_bin), "--memory", "-1"])
     # missing prefs
     with pytest.raises(SystemExit):
         parse_args([str(fake_bin), "-p", str(tmp_path / "missing")])


### PR DESCRIPTION
Previously logs would only be saved if `-l` was specified. Now if a potential issue is detected the log is always saved to disk. By default if a potential issue is not detected the logs are discarded this can be overridden with `--save-all`