### PR TITLE
Fix missing sanitizer logs from TSan

### DIFF
--- a/ffpuppet/helpers.py
+++ b/ffpuppet/helpers.py
@@ -159,6 +159,9 @@ def configure_sanitizers(env, target_dir, log_path):
     tsan_config = SanitizerConfig()
     tsan_config.load_options(env, "TSAN_OPTIONS")
     tsan_config.add("halt_on_error", "1")
+    if "log_path" in tsan_config:
+        log.warning("TSAN_OPTIONS=log_path is used internally and cannot be set externally")
+    tsan_config.add("log_path", "'%s'" % log_path, overwrite=True)
     env["TSAN_OPTIONS"] = tsan_config.options
 
     # setup Undefined Behavior Sanitizer options if not set manually

--- a/ffpuppet/helpers.py
+++ b/ffpuppet/helpers.py
@@ -370,6 +370,7 @@ def prepare_environment(target_dir, sanitizer_log, env_mod=None):
     base["MOZ_DISABLE_NPAPI_SANDBOX"] = "1"
     base["MOZ_DISABLE_PDFIUM_SANDBOX"] = "1"
     base["MOZ_DISABLE_RDD_SANDBOX"] = "1"
+    base["MOZ_DISABLE_SOCKET_PROCESS_SANDBOX"] = "1"
     base["MOZ_DISABLE_VR_SANDBOX"] = "1"
     base["MOZ_GDB_SLEEP"] = "0"
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1305151

--- a/ffpuppet/puppet_logger.py
+++ b/ffpuppet/puppet_logger.py
@@ -26,14 +26,14 @@ class PuppetLogger(object):
     PREFIX_SAN = "ffp_asan_%d.log" % os.getpid()
     PREFIX_VALGRIND = "valgrind.%d" % os.getpid()
 
-    __slots__ = ("_base", "_logs", "_rr_packed", "closed", "ignored", "working_path")
+    __slots__ = ("_base", "_logs", "_rr_packed", "closed", "watching", "working_path")
 
     def __init__(self, base_path=None):
         self._base = base_path
         self._logs = dict()
         self._rr_packed = False
         self.closed = True
-        self.ignored = list()
+        self.watching = dict()
         self.working_path = None
         self.reset()
 


### PR DESCRIPTION
TSan logs that contained benign warnings would be ignored so if they later contained a valid report the would be missed.