### PR TITLE
Reconfigure linters.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,22 @@
 repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.1
+    hooks:
+      - id: isort
   - repo: https://github.com/asottile/yesqa
-    rev: v1.2.2
+    rev: v1.2.3
     hooks:
       - id: yesqa
+  - repo: https://github.com/ambv/black
+    rev: 21.6b0
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -19,6 +31,11 @@ repos:
         args: ['--django']
       - id: check-json
       - id: requirements-txt-fixer
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        exclude_types: [json]
   - repo: https://github.com/marco-c/taskcluster_yml_validator
     rev: v0.0.7
     hooks:
@@ -32,11 +49,11 @@ repos:
       - id: check-useless-excludes
   - repo: local
     hooks:
-      - id: lint
-        name: Run linters
-        entry: tox -e lint
+      - id: pylint
+        name: pylint
+        entry: tox -e pylint --
         language: system
-        pass_filenames: false
+        require_serial: true
         types: [python]
 
 default_language_version:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -51,12 +51,6 @@ tasks:
               TOXENV: lint
             script:
               - tox
-          - name: precommit
-            version: "3.9"
-            env:
-              TOXENV: precommit
-            script:
-              - tox
           - name: PyPI upload
             version: "3.8"
             env:

--- a/ffpuppet/resources/testff.py
+++ b/ffpuppet/resources/testff.py
@@ -63,9 +63,11 @@ def main():  # pylint: disable=missing-docstring
     target_url = None
     if url:
         try:
+            # pylint: disable=consider-using-with
             conn = urlopen(url)
         except URLError as req_err:
             # can't redirect to file:// from http://
+            # pylint: disable=consider-using-with
             conn = urlopen(req_err.reason.split("'")[1])
         try:
             target_url = conn.geturl()

--- a/tox.ini
+++ b/tox.ini
@@ -29,28 +29,18 @@ deps =
     coverage[toml]
 skip_install = true
 
-[testenv:precommit]
+[testenv:lint]
 commands =
-    pre-commit run -a
+    pre-commit run -a {posargs}
 deps =
     pre-commit
 skip_install = true
 
-[testenv:lint]
-allowlist_externals =
-    bash
+[testenv:pylint]
 commands =
-    isort --check-only {toxinidir}
-    black --check {toxinidir}
-    codespell {toxinidir} --skip=".git,.tox,htmlcov"
-    pylint {toxinidir}/ffpuppet
-    flake8 {toxinidir}
+    pylint {posargs}
 deps =
-    black
-    codespell
-    flake8
-    isort
-    pylint
+    pylint==2.8.3
 usedevelop = true
 
 [testenv:pypi]


### PR DESCRIPTION
Allow pre-commit to control all versions except pylint, which is configured in a toxenv to allow dependencies to be installed.

If a new linter version is released and it requires code changes, this would not be run by an existing tox environment locally, so it would first be noticed when it is run in CI.