### PR TITLE
Add macOS CI

### DIFF
--- a/.github/scripts/start-worker.sh
+++ b/.github/scripts/start-worker.sh
@@ -1,0 +1,58 @@
+#!/bin/sh -e
+
+[ -z "$TASKCLUSTER_ACCESS_TOKEN" ] && echo "Missing TASKCLUSTER_ACCESS_TOKEN" >&2 && exit 2
+[ -z "$TC_WORKER_ID" ] && echo "Missing TC_WORKER_ID" >&2 && exit 2
+
+set -x
+
+TC_VERSION=v44.4.0
+TC_PROJECT=fuzzing
+TC_WORKER_TYPE=ci-osx
+TC_IDLE_TIMEOUT=300
+
+TASKCLUSTER_ROOT_URL="https://community-tc.services.mozilla.com"
+TASKCLUSTER_CLIENT_ID="project/$TC_PROJECT/worker-$TC_WORKER_TYPE-gh"
+
+set +x
+cat > worker.config <<EOF
+{
+  "accessToken": "$TASKCLUSTER_ACCESS_TOKEN",
+  "clientId": "$TASKCLUSTER_CLIENT_ID",
+  "disableReboots": true,
+  "ed25519SigningKeyLocation": "worker.key",
+  "idleTimeoutSecs": $TC_IDLE_TIMEOUT,
+  "livelogExecutable": "$PWD/livelog",
+  "provisionerId": "proj-$TC_PROJECT",
+  "publicIP": "127.0.0.1",
+  "requiredDiskSpaceMegabytes": 512,
+  "rootURL": "$TASKCLUSTER_ROOT_URL",
+  "sentryProject": "generic-worker",
+  "taskclusterProxyExecutable": "$PWD/taskcluster-proxy",
+  "taskclusterProxyPort": 8080,
+  "tasksDir": "tasks",
+  "workerGroup": "proj-$TC_PROJECT",
+  "workerId": "$TC_WORKER_ID",
+  "workerType": "$TC_WORKER_TYPE",
+  "wstAudience": "communitytc",
+  "wstServerURL": "https://community-websocktunnel.services.mozilla.com"
+}
+EOF
+set -x
+unset TASKCLUSTER_ACCESS_TOKEN
+
+curl -sSL "https://github.com/taskcluster/taskcluster/releases/download/$TC_VERSION/generic-worker-simple-darwin-amd64" -o generic-worker
+curl -sSL "https://github.com/taskcluster/taskcluster/releases/download/$TC_VERSION/livelog-darwin-amd64" -o livelog
+curl -sSL "https://github.com/taskcluster/taskcluster/releases/download/$TC_VERSION/taskcluster-proxy-darwin-amd64" -o taskcluster-proxy
+chmod +x generic-worker livelog taskcluster-proxy
+
+./generic-worker new-ed25519-keypair --file worker.key
+mkdir tasks
+set +e
+./generic-worker run --config worker.config
+case $? in
+0|68)
+  ;;
+*)
+  exit $?
+  ;;
+esac

--- a/.github/workflows/taskcluster-pr.yml
+++ b/.github/workflows/taskcluster-pr.yml
@@ -1,0 +1,11 @@
+name: taskcluster PR worker
+on: [pull_request]
+jobs:
+  osx-tc-worker-pr:
+    runs-on: macos-10.15
+    env:
+      TASKCLUSTER_ACCESS_TOKEN: ${{ secrets.TASKCLUSTER_ACCESS_TOKEN }}
+      TC_WORKER_ID: "gh-ffpuppet-pr-${{ github.run_id }}-${{ github.run_attempt }}"
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/start-worker.sh

--- a/.github/workflows/taskcluster-push.yml
+++ b/.github/workflows/taskcluster-push.yml
@@ -1,0 +1,11 @@
+name: taskcluster push worker
+on: [push]
+jobs:
+  osx-tc-worker-push:
+    runs-on: macos-10.15
+    env:
+      TASKCLUSTER_ACCESS_TOKEN: ${{ secrets.TASKCLUSTER_ACCESS_TOKEN }}
+      TC_WORKER_ID: "gh-ffpuppet-push-${{ github.run_id }}-${{ github.run_attempt }}"
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/start-worker.sh

--- a/.github/workflows/taskcluster-release.yml
+++ b/.github/workflows/taskcluster-release.yml
@@ -1,0 +1,11 @@
+name: taskcluster release worker
+on: [release]
+jobs:
+  osx-tc-worker-release:
+    runs-on: macos-10.15
+    env:
+      TASKCLUSTER_ACCESS_TOKEN: ${{ secrets.TASKCLUSTER_ACCESS_TOKEN }}
+      TC_WORKER_ID: "gh-ffpuppet-release-${{ github.run_id }}-${{ github.run_attempt }}"
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/start-worker.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: taskcluster_yml
   - repo: https://github.com/MozillaSecurity/orion
-    rev: v0.0.2
+    rev: v0.0.4
     hooks:
       - id: orion_ci
   - repo: meta

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -32,6 +32,11 @@ tasks:
             version: "3.8"
             env:
               TOXENV: py38
+          - name: test python 3.8 (macos)
+            version: "3.8"
+            platform: macos
+            env:
+              TOXENV: py38
           - name: test python 3.8 (windows)
             version: "3.8"
             platform: windows
@@ -39,6 +44,11 @@ tasks:
               TOXENV: py38
           - name: tests python 3.9
             version: "3.9"
+            env:
+              TOXENV: py39
+          - name: test python 3.9 (macos)
+            version: "3.9"
+            platform: macos
             env:
               TOXENV: py39
           - name: lint

--- a/ffpuppet/test_ffpuppet.py
+++ b/ffpuppet/test_ffpuppet.py
@@ -696,6 +696,7 @@ def test_ffpuppet_27(mocker, tmp_path):
             self.profile = None
 
     is_linux = platform.system() == "Linux"
+    # only check Valgrind logs on Linux
     debugger = Debugger.VALGRIND if is_linux else Debugger.NONE
     with StubbedLaunch(debugger=debugger) as ffp:
         assert ffp._dbg == debugger
@@ -725,7 +726,6 @@ def test_ffpuppet_27(mocker, tmp_path):
         # nothing interesting
         (Path(ffp.profile) / "minidumps" / "test.junk").write_text("\n")
         assert not ffp._logs.watching
-        # NOTE: Valgrind logs are only checked on Linux
         assert len(list(ffp._crashreports())) == (3 if is_linux else 2)
         assert ffp._logs.watching
         assert len(list(ffp._crashreports(skip_md=True))) == (2 if is_linux else 1)
@@ -734,7 +734,7 @@ def test_ffpuppet_27(mocker, tmp_path):
             # not tested on Windows because chmod() does not work
             ffp._logs.watching.clear()
             ign_log.chmod(stat.S_IWRITE)
-            assert len(list(ffp._crashreports())) == 4
+            assert len(list(ffp._crashreports())) == (4 if is_linux else 3)
             assert not ffp._logs.watching
 
 


### PR DESCRIPTION
This uses gh-actions only to provide macOS workers for Taskcluster to run the macOS jobs. Everything under .github is boiler-plate copied from Orion to make that work.

The gh-actions tasks will always succeed and can be ignored. The CI jobs are still managed by Taskcluster.