### PR TITLE
Add support for built in browser headless mode

### DIFF
--- a/ffpuppet/resources/testff.py
+++ b/ffpuppet/resources/testff.py
@@ -16,7 +16,7 @@ def main() -> int:  # pylint: disable=missing-docstring
     profile = url = None
     while len(sys.argv) > 1:
         arg = sys.argv.pop(1)
-        if arg in ("-no-remote",):
+        if arg in ("-headless", "-no-remote"):
             pass
         elif os_name == "Windows" and arg in ("-no-deelevate", "-wait-for-browser"):
             pass

--- a/ffpuppet/test_main.py
+++ b/ffpuppet/test_main.py
@@ -87,6 +87,26 @@ def test_parse_args_01(tmp_path):
     assert parse_args([str(fake_bin)])
 
 
+def test_parse_args_02(mocker, tmp_path):
+    """test parse_args() - headless"""
+    fake_system = mocker.patch("ffpuppet.main.system", autospec=True)
+    fake_bin = tmp_path / "fake.bin"
+    fake_bin.touch()
+    # no headless
+    assert parse_args([str(fake_bin)]).headless is None
+    # headless (default)
+    assert parse_args([str(fake_bin), "--headless"]).headless == "default"
+    # headless via Xvfb
+    fake_system.return_value = "Linux"
+    assert parse_args([str(fake_bin), "--headless", "xvfb"]).headless == "xvfb"
+    # --xvfb flag
+    assert parse_args([str(fake_bin), "--xvfb"]).headless == "xvfb"
+    # headless Xvfb unsupported
+    fake_system.return_value = "Windows"
+    with raises(SystemExit):
+        parse_args([str(fake_bin), "--headless", "xvfb"])
+
+
 def test_dump_to_console_01(tmp_path):
     """test dump_to_console()"""
     # call with no logs


### PR DESCRIPTION
This replaces --xvfb with --headless.
Xvfb is still supported via --headless xvfb.