### PR TITLE
Reduce the number of calls to open_files()

### DIFF
--- a/src/ffpuppet/core.py
+++ b/src/ffpuppet/core.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     pass
 
-from psutil import AccessDenied, NoSuchProcess, Process, process_iter, wait_procs
+from psutil import AccessDenied, NoSuchProcess, Process, wait_procs
 
 try:
     from xvfbwrapper import Xvfb
@@ -535,9 +535,7 @@ class FFPuppet:
             # create a list of processes that are using the stderr file
             # this *should* only include the browser and the current Python process
             procs = []
-            for _, other_pid, _ in files_in_use(
-                [Path(stderr_fp.name)], process_iter(["pid", "name", "open_files"])
-            ):
+            for _, other_pid, _ in files_in_use([Path(stderr_fp.name)]):
                 # don't include the current Python process in the results
                 if other_pid != getpid():
                     try:

--- a/src/ffpuppet/test_ffpuppet.py
+++ b/src/ffpuppet/test_ffpuppet.py
@@ -120,6 +120,7 @@ def test_ffpuppet_01():
 )
 def test_ffpuppet_02(mocker, exc_type):
     """test launch failures"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
     mocker.patch("ffpuppet.core.Popen", autospec=True)
     fake_bts = mocker.patch("ffpuppet.core.Bootstrapper", autospec=True)
     fake_bts.return_value.location = ""
@@ -131,8 +132,9 @@ def test_ffpuppet_02(mocker, exc_type):
         assert ffp.launches == 0
 
 
-def test_ffpuppet_03(tmp_path):
+def test_ffpuppet_03(mocker, tmp_path):
     """test logging"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
     with FFPuppet() as ffp:
         ffp.close()
         ffp.save_logs(str(tmp_path / "no_logs"))
@@ -340,6 +342,7 @@ def test_ffpuppet_12():
 
 def test_ffpuppet_13(mocker):
     """test launching under Xvfb"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
     mocker.patch("ffpuppet.core.Popen", autospec=True)
     fake_bts = mocker.patch("ffpuppet.core.Bootstrapper", autospec=True)
     fake_bts.return_value.location = "http://test:123"
@@ -369,8 +372,9 @@ def test_ffpuppet_13(mocker):
     assert fake_xvfb.start.call_count == 0
 
 
-def test_ffpuppet_14(tmp_path):
+def test_ffpuppet_14(mocker, tmp_path):
     """test passing a file and a non existing file to launch() via location"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
     with FFPuppet() as ffp:
         with raises(OSError, match="Cannot find"):
             ffp.launch(TESTFF_BIN, location="missing.file")
@@ -537,8 +541,10 @@ def test_ffpuppet_21(tmp_path):
         )
 
 
-def test_ffpuppet_22(tmp_path):
+def test_ffpuppet_22(mocker, tmp_path):
     """test collecting and cleaning up ASan logs"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
+    mocker.patch("ffpuppet.core.wait_on_files", autospec=True)
     test_logs = []
     with FFPuppet() as ffp:
         ffp.launch(TESTFF_BIN)
@@ -600,6 +606,8 @@ def test_ffpuppet_22(tmp_path):
 
 def test_ffpuppet_23(mocker, tmp_path):
     """test multiple minidumps"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
+    mocker.patch("ffpuppet.core.wait_on_files", autospec=True)
 
     # pylint: disable=unused-argument
     def _fake_process_minidumps(dmps, _, add_log, working_path=None):
@@ -920,6 +928,7 @@ def test_ffpuppet_31(mocker):
 
 def test_ffpuppet_32(mocker, tmp_path):
     """test FFPuppet.close() setting reason"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
 
     class StubbedProc(FFPuppet):
         # pylint: disable=arguments-differ
@@ -1058,6 +1067,7 @@ def test_ffpuppet_35(mocker, tmp_path, bin_exists, expect_exc):
 @mark.skipif(system() != "Windows", reason="Only supported on Windows")
 def test_ffpuppet_36(mocker):
     """test FFPuppet.launch() config_job_object code path"""
+    mocker.patch("ffpuppet.core.files_in_use", autospec=True)
     fake_bts = mocker.patch("ffpuppet.core.Bootstrapper", autospec=True)
     fake_bts.return_value.location = ""
     fake_popen = mocker.patch("ffpuppet.core.Popen", autospec=True)

--- a/src/ffpuppet/test_helpers.py
+++ b/src/ffpuppet/test_helpers.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from platform import system
 from shutil import rmtree
 
-from psutil import Process as PSProcess
 from pytest import raises
 
 from .helpers import (
@@ -427,12 +426,15 @@ def test_helpers_10(tmp_path):
     """test files_in_use()"""
     t_file = tmp_path / "file.bin"
     t_file.touch()
-    procs = [PSProcess(os.getpid())]
     # test with open file
     with (tmp_path / "file").open("w") as wait_fp:
-        assert any(files_in_use([t_file, Path(wait_fp.name)], procs))
+        assert any(files_in_use([t_file, Path(wait_fp.name)]))
     # existing but closed file
-    assert not any(files_in_use([t_file], procs))
+    assert not any(files_in_use([t_file]))
+    # missing file
+    assert not any(files_in_use([tmp_path / "missing_file"]))
+    # no files
+    assert not any(files_in_use([]))
 
 
 def test_helpers_11(tmp_path):


### PR DESCRIPTION
Attempt to make files_in_use() as reliable as possible. This does cause minor slow downs on Windows but is mostly only noticeable when running tests.