### PR TITLE
Include minidump-stackwalk errors in minidump logs

### DIFF
--- a/src/ffpuppet/core.py
+++ b/src/ffpuppet/core.py
@@ -12,6 +12,7 @@ from platform import system
 from re import IGNORECASE
 from re import compile as re_compile
 from re import match as re_match
+from shutil import copyfileobj
 from subprocess import Popen, check_output
 from sys import executable
 from typing import Any, Dict, Iterator, List, Optional, Pattern, Set, Tuple, Union
@@ -602,12 +603,12 @@ class FFPuppet:
                 if not sym_path.is_dir():
                     # use packaged symbols
                     sym_path = self._bin_path / "symbols"
-                process_minidumps(
-                    md_path,
-                    sym_path,
-                    self._logs.add_log,
-                    working_path=self._working_path,
-                )
+                for md_txt in process_minidumps(md_path, sym_path):
+                    with md_txt.open("rb") as md_fp:
+                        copyfileobj(
+                            md_fp, self._logs.add_log(md_txt.stem)
+                        )  # type: ignore
+
             stderr_fp = self._logs.get_fp("stderr")
             if stderr_fp:
                 stderr_fp.write(f"[ffpuppet] Exit code: {self._proc.poll()}\n".encode())

--- a/src/ffpuppet/test_ffpuppet.py
+++ b/src/ffpuppet/test_ffpuppet.py
@@ -575,11 +575,11 @@ def test_ffpuppet_21(tmp_path):
 def test_ffpuppet_22(mocker, tmp_path):
     """test multiple minidumps"""
 
-    # pylint: disable=unused-argument
-    def _fake_process_minidumps(dmps, _, add_log, working_path=None):
+    def _fake_process_minidumps(dmps, _):
         for num, _ in enumerate(Path(dmps).glob("*.dmp")):
-            lfp = add_log(f"minidump_{num + 1:02}")
-            lfp.write(b"test")
+            md_log = tmp_path / f"minidump_{num:02}.txt"
+            md_log.write_text("test")
+            yield md_log
 
     mocker.patch("ffpuppet.core.process_minidumps", side_effect=_fake_process_minidumps)
     profile = tmp_path / "profile"
@@ -600,9 +600,9 @@ def test_ffpuppet_22(mocker, tmp_path):
         ffp.close()
         logs = tmp_path / "logs"
         ffp.save_logs(logs)
+        assert any(logs.glob("log_minidump_00.txt"))
         assert any(logs.glob("log_minidump_01.txt"))
         assert any(logs.glob("log_minidump_02.txt"))
-        assert any(logs.glob("log_minidump_03.txt"))
 
 
 def test_ffpuppet_23(tmp_path):


### PR DESCRIPTION
This makes minidump reporting function more like sanitizers.