### PR TITLE
Use localhost instead of 127.0.0.1 for bootstrapping

### DIFF
--- a/src/ffpuppet/bootstrapper.py
+++ b/src/ffpuppet/bootstrapper.py
@@ -54,7 +54,7 @@ class Bootstrapper:  # pylint: disable=missing-docstring
             self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self._socket.settimeout(self.POLL_WAIT)
             try:
-                self._socket.bind(("127.0.0.1", port))
+                self._socket.bind(("localhost", port))
                 self._socket.listen(5)
             except (OSError, PermissionError) as exc:
                 LOG.debug("%s: %s", type(exc).__name__, exc)
@@ -91,7 +91,7 @@ class Bootstrapper:  # pylint: disable=missing-docstring
 
     @property
     def location(self) -> str:
-        """Location in the format of 'http://127.0.0.1:#'.
+        """Location in the format of 'http://localhost:#'.
 
         Args:
             None
@@ -100,7 +100,7 @@ class Bootstrapper:  # pylint: disable=missing-docstring
             Location.
         """
         assert self._socket is not None
-        return f"http://127.0.0.1:{self.port}"
+        return f"http://localhost:{self.port}"
 
     @property
     def port(self) -> int:

--- a/src/ffpuppet/test_bootstrapper.py
+++ b/src/ffpuppet/test_bootstrapper.py
@@ -19,7 +19,7 @@ def test_bootstrapper_01():
     """test simple Bootstrapper()"""
     with Bootstrapper() as bts:
         assert bts._socket is not None
-        assert bts.location.startswith("http://127.0.0.1:")
+        assert bts.location.startswith("http://localhost:")
         assert int(bts.location.split(":")[-1]) > 1024
         assert bts.port > 1024
         assert bts.port not in Bootstrapper.BLOCKED_PORTS
@@ -116,7 +116,7 @@ def test_bootstrapper_05(mocker):
         # normal startup
         (None, ("foo",), 1),
         # with a redirect url
-        ("http://127.0.0.1:9999/test.html", ("foo",), 1),
+        ("http://localhost:9999/test.html", ("foo",), 1),
         # request size matches buffer size
         (None, ("A" * Bootstrapper.BUF_SIZE, timeout), 1),
         # large request
@@ -151,7 +151,7 @@ def test_bootstrapper_07():
         # open connection
         for attempt in reversed(range(50)):
             try:
-                conn.connect(("127.0.0.1", port))
+                conn.connect(("localhost", port))
                 break
             except timeout:
                 if not attempt:

--- a/src/ffpuppet/test_ffpuppet.py
+++ b/src/ffpuppet/test_ffpuppet.py
@@ -45,7 +45,7 @@ class HTTPTestServer:
         self._handler = ReqHandler
         while True:
             try:
-                self._httpd = HTTPServer(("127.0.0.1", 0), self._handler)
+                self._httpd = HTTPServer(("localhost", 0), self._handler)
             except OSError as soc_e:
                 if soc_e.errno in (EADDRINUSE, 10013):
                     # Address already in use
@@ -62,7 +62,7 @@ class HTTPTestServer:
         self.shutdown()
 
     def get_addr(self):
-        return f"http://127.0.0.1:{self._httpd.server_address[1]}"
+        return f"http://localhost:{self._httpd.server_address[1]}"
 
     def shutdown(self):
         if self._httpd is not None:


### PR DESCRIPTION
This is required as part of https://github.com/MozillaSecurity/grizzly/pull/374 to ensure that the initial harness page is loaded on `localhost` instead of `127.0.0.1`.  I'm unsure if the disparity between the two will cause cross origin issues or not but there's no harm in changing it.