### PR TITLE
Do not use --chaos flag with rr

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ url = https://github.com/MozillaSecurity/ffpuppet
 [options]
 include_package_data = True
 install_requires =
-    psutil >= 4.4.0
+    psutil >= 5.9.0
     xvfbwrapper >= 0.2.9; sys_platform == "linux" or sys_platform == "linux2"
 package_dir =
     = src

--- a/src/ffpuppet/core.py
+++ b/src/ffpuppet/core.py
@@ -480,7 +480,6 @@ class FFPuppet:
             ]
             if self._dbg == Debugger.PERNOSCO:
                 rr_cmd += [
-                    "--chaos",
                     "--disable-cpuid-features-ext",
                     "0xdc230000,0x2c42,0xc",
                 ]

--- a/src/ffpuppet/test_ffpuppet.py
+++ b/src/ffpuppet/test_ffpuppet.py
@@ -736,13 +736,13 @@ def test_ffpuppet_26(mocker, tmp_path):
         cmd = ffp.build_launch_cmd("bin_path")
         assert len(cmd) > 2
         assert cmd[0] == "rr"
-        assert "--chaos" in cmd
+        assert "--disable-cpuid-features-ext" in cmd
         # RR
         ffp._dbg = Debugger.RR
         cmd = ffp.build_launch_cmd("bin_path")
         assert len(cmd) > 2
         assert cmd[0] == "rr"
-        assert "--chaos" not in cmd
+        assert "--disable-cpuid-features-ext" not in cmd
         # Valgrind
         ffp._dbg = Debugger.VALGRIND
         mocker.patch.dict(os.environ, {"VALGRIND_SUP_PATH": "blah"})


### PR DESCRIPTION
Using the --chaos flag typically decrease browser performance. It also makes reproducing some issues much more difficult. At the moment it also causes random crashes. For more details see: https://bugzilla.mozilla.org/show_bug.cgi?id=1858295