### PR TITLE
Handle using launcher as parent process

### DIFF
--- a/src/ffpuppet/process_tree.py
+++ b/src/ffpuppet/process_tree.py
@@ -75,27 +75,23 @@ class ProcessTree:
             except (AccessDenied, NoSuchProcess):  # pragma: no cover
                 LOG.debug("call to self.parent.cmdline() failed")
                 cmd = []
-            # disable during testing with testff.py
-            if "testff.py" in "".join(cmd):
-                self._launcher_check = False
-                LOG.debug("testff.py in use launcher_check disabled")
             # check if launcher process is in use
-            elif "-no-deelevate" in cmd:
-                LOG.debug("launcher process detected")
+            if "-no-deelevate" in cmd:
                 launcher_children = self.parent.children(recursive=False)
                 # launcher should only have one child process
                 if len(launcher_children) == 1:
+                    LOG.debug("launcher process detected")
                     self._launcher = self.parent
                     self.parent = launcher_children[0]
                 else:
-                    # launcher is parent process? or parent does not exist?
-                    # we expect `launcher -> parent -> content procs`
-                    # this seems to happen sometimes... no idea why
-                    # appears to be harmless so allow it for now
-                    LOG.warning(
-                        "Failed to select launcher. Process has %d child proc(s)",
+                    # this is expected behaviour when setting:
+                    # - `browser.launcherProcess.enabled=false`
+                    # it can also happen for unknown reasons...
+                    LOG.debug(
+                        "using launcher as parent, %d child proc(s) detected",
                         len(launcher_children),
                     )
+                self._launcher_check = False
         return self._launcher
 
     @staticmethod

--- a/src/ffpuppet/resources/tree.py
+++ b/src/ffpuppet/resources/tree.py
@@ -48,7 +48,7 @@ def main(args: Namespace) -> int:
             "--duration",
             str(args.duration),
         ]
-        if args.no_deelevate:
+        if args.no_deelevate and not args.launcher_is_parent:
             assert not args.contentproc, f"-contentproc not expected! ({pid})"
             LOG.info("Launcher process")
             # pylint: disable=consider-using-with
@@ -61,6 +61,7 @@ def main(args: Namespace) -> int:
                 conn.settimeout(SOCKET_TIMEOUT)
                 conn.sendall(str(pid).encode())
         else:
+            assert not args.no_deelevate or args.launcher_is_parent
             LOG.info("Parent process (ppid: %r)", args.parent_pid)
             with socket(AF_INET, SOCK_STREAM) as srv:
                 srv.settimeout(SOCKET_TIMEOUT)
@@ -109,6 +110,7 @@ if __name__ == "__main__":
     parser.add_argument("procs", type=int, help="number of content processes")
     parser.add_argument("sync", type=Path, help="used to indicate tree readiness")
     parser.add_argument("--duration", type=int, default=60)
+    parser.add_argument("--launcher-is-parent", action="store_true")
     parser.add_argument("--parent-pid", type=int)
     parser.add_argument("--port", type=int)
     parser.add_argument("-contentproc", action="store_true", help="fake browser arg")


### PR DESCRIPTION
This is the case when `browser.launcherProcess.enabled=false` is used. It can also happen from time to time for unknown reasons.