### PR TITLE
fix: [compiler-rt] Fix frame numbering for unparsable frames.

### DIFF
--- a/src/ffpuppet/asan_symbolize.py
+++ b/src/ffpuppet/asan_symbolize.py
@@ -23,7 +23,6 @@ script itself.
 import argparse
 import bisect
 import errno
-import getopt
 import logging
 import os
 import re
@@ -38,6 +37,7 @@ fix_filename_patterns = None
 logfile = sys.stdin
 allow_system_symbolizer = True
 force_system_symbolizer = False
+
 
 # FIXME: merge the code that calls fix_filename().
 def fix_filename(file_name):
@@ -508,20 +508,29 @@ class SymbolizationLoop(object):
         assert result
         return result
 
-    def get_symbolized_lines(self, symbolized_lines, inc_frame_counter=True):
+    def get_symbolized_lines(self, symbolized_lines):
         if not symbolized_lines:
-            if inc_frame_counter:
-                self.frame_no += 1
-            return [self.current_line]
-        else:
-            assert inc_frame_counter
-            result = []
-            for symbolized_frame in symbolized_lines:
-                result.append(
-                    "    #%s %s" % (str(self.frame_no), symbolized_frame.rstrip())
+            # If it is an unparsable frame, but contains a frame counter and address
+            # replace the frame counter so the stack is still consistent.
+            unknown_stack_frame_format = r"^( *#([0-9]+) +)(0x[0-9a-f]+) +.*"
+            match = re.match(unknown_stack_frame_format, self.current_line)
+            if match:
+                rewritten_line = (
+                    self.current_line[: match.start(2)]
+                    + str(self.frame_no)
+                    + self.current_line[match.end(2) :]
                 )
                 self.frame_no += 1
-            return result
+                return [rewritten_line]
+            # Not a frame line so don't increment the frame counter.
+            return [self.current_line]
+        result = []
+        for symbolized_frame in symbolized_lines:
+            result.append(
+                "    #%s %s" % (str(self.frame_no), symbolized_frame.rstrip())
+            )
+            self.frame_no += 1
+        return result
 
     def process_logfile(self):
         self.frame_no = 0
@@ -547,8 +556,7 @@ class SymbolizationLoop(object):
         match = re.match(stack_trace_line_format, line)
         if not match:
             logging.debug('Line "{}" does not match regex'.format(line))
-            # Not a frame line so don't increment the frame counter.
-            return self.get_symbolized_lines(None, inc_frame_counter=False)
+            return self.get_symbolized_lines(None)
         logging.debug(line)
         _, frameno_str, addr, binary, offset = match.groups()
 
@@ -604,6 +612,7 @@ class AsanSymbolizerPlugInProxy(object):
     def load_plugin_from_file(self, file_path):
         logging.info('Loading plugins from "{}"'.format(file_path))
         globals_space = dict(globals())
+
         # Provide function to register plugins
         def register_plugin(plugin):
             logging.info("Registering plugin %s", plugin.get_name())
@@ -780,9 +789,13 @@ class ModuleDesc(object):
             arch=self.arch,
             start_addr=self.start_addr,
             end_addr=self.end_addr,
-            module_path=self.module_path
-            if self.module_path == self.module_path_for_symbolization
-            else "{} ({})".format(self.module_path_for_symbolization, self.module_path),
+            module_path=(
+                self.module_path
+                if self.module_path == self.module_path_for_symbolization
+                else "{} ({})".format(
+                    self.module_path_for_symbolization, self.module_path
+                )
+            ),
             uuid=self.uuid,
         )
 


### PR DESCRIPTION
This can happen when JIT code is run, and we can't symbolize those frames, but they should remain numbered in the stack.

see: https://github.com/llvm/llvm-project/pull/148278